### PR TITLE
Add GraphQL plugin for fastify with GraphiQL

### DIFF
--- a/part-1-hello-world/README.md
+++ b/part-1-hello-world/README.md
@@ -7,3 +7,8 @@
 - Fix any issues with people
 - install graphiQL - to view data (separate viewing)
 - Visit graphQL endpoint and demonstrate
+
+
+## GraphiQL
+
+http://127.0.0.1:3000/graphiql.html

--- a/part-1-hello-world/package-lock.json
+++ b/part-1-hello-world/package-lock.json
@@ -2575,6 +2575,20 @@
         "tiny-lru": "^6.0.1"
       }
     },
+    "fastify-gql": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fastify-gql/-/fastify-gql-1.3.0.tgz",
+      "integrity": "sha512-NMlaYkTVOmf0DZgd7mQrgg4TuZQ5QU4cgCLvF5qgDf1kDGX+vjgttjowUPB5qjDyPBI/JmoYpjkJAOIDNfvtVQ==",
+      "requires": {
+        "fastify-plugin": "^1.5.0",
+        "fastify-static": "^2.3.2",
+        "graphql": "^14.3.0",
+        "graphql-jit": "^0.2.0",
+        "http-errors": "^1.7.2",
+        "single-user-cache": "^0.3.0",
+        "tiny-lru": "^6.0.0"
+      }
+    },
     "fastify-plugin": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-1.6.0.tgz",
@@ -2880,8 +2894,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2902,14 +2915,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2924,20 +2935,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3054,8 +3062,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3067,7 +3074,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3082,7 +3088,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3090,14 +3095,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3116,7 +3119,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3197,8 +3199,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3210,7 +3211,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3296,8 +3296,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3333,7 +3332,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3353,7 +3351,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3397,14 +3394,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3530,6 +3525,26 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
+    "graphql": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.3.1.tgz",
+      "integrity": "sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-jit": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-jit/-/graphql-jit-0.2.0.tgz",
+      "integrity": "sha512-sySSVlUEt6W3NpPRhtsrOzpb4xw7DWKCHnxD5LUeIsTxJT2lbNpY9BII7cZaOL6DRCzXXv2S5Wo3+6UmMLlbUg==",
+      "requires": {
+        "fast-json-stringify": "^1.13.0",
+        "json-schema": "^0.2.3",
+        "lodash.memoize": "^4.1.2",
+        "lodash.merge": "^4.6.1",
+        "lodash.mergewith": "^4.6.1"
+      }
+    },
     "gud": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
@@ -3617,6 +3632,30 @@
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
+      }
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
       }
     },
     "https-browserify": {
@@ -3956,6 +3995,11 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
+    "iterall": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -3984,6 +4028,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -4104,6 +4153,21 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5498,6 +5562,11 @@
         "ret": "~0.2.0"
       }
     },
+    "safe-stable-stringify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.0.tgz",
+      "integrity": "sha512-8h+96qSufNQrydRPzbHms38VftQQSRGbqUkaIMWUBWN4/N8sLNALIALa8KmFcQ8P/a9uzMkA+KY04Rj5WQiXPA=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5676,6 +5745,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "single-user-cache": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/single-user-cache/-/single-user-cache-0.3.0.tgz",
+      "integrity": "sha512-ykG6KBaw2V/CO0HggkHN6x4CkDyQQ6hTSK24zVmfL4gJKF8BUyZfg+EKrurakQ8EIh8YuHpy2R9SYgiZV/Az9g==",
+      "requires": {
+        "safe-stable-stringify": "^1.1.0"
+      }
     },
     "slash": {
       "version": "2.0.0",
@@ -6223,6 +6300,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "touch": {
       "version": "3.1.0",

--- a/part-1-hello-world/package.json
+++ b/part-1-hello-world/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@reach/router": "^1.2.1",
     "fastify": "^2.4.1",
+    "fastify-gql": "^1.3.0",
     "fastify-static": "^2.4.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/part-1-hello-world/src/server/graphql/index.js
+++ b/part-1-hello-world/src/server/graphql/index.js
@@ -1,0 +1,18 @@
+const fastifyGQL = require('fastify-gql')
+
+const schema = require('./schema')
+const resolvers = require('./resolvers')
+
+function registerGraphQL(fastify, opts, next) {
+  fastify.register(fastifyGQL, {
+    schema,
+    resolvers,
+    graphiql: true
+  })
+
+  next()
+}
+
+registerGraphQL[Symbol.for('skip-override')] = true
+
+module.exports = registerGraphQL

--- a/part-1-hello-world/src/server/graphql/resolvers.js
+++ b/part-1-hello-world/src/server/graphql/resolvers.js
@@ -1,0 +1,13 @@
+const posts = []
+
+module.exports = {
+  Query: {
+    posts: (_, {}) => posts
+  },
+  Mutation: {
+    createPost: (_, post) => {
+      posts.push(post)
+      return post
+    }
+  }
+}

--- a/part-1-hello-world/src/server/graphql/schema.js
+++ b/part-1-hello-world/src/server/graphql/schema.js
@@ -1,0 +1,12 @@
+module.exports = `
+  type Post {
+    title: String
+    body: String
+  }
+  type Query {
+    posts: [Post]
+  }
+  type Mutation {
+    createPost(title: String!, body: String!): Post
+  }
+`

--- a/part-1-hello-world/src/server/index.js
+++ b/part-1-hello-world/src/server/index.js
@@ -1,6 +1,9 @@
 const path = require('path')
 const fastify = require('fastify')
 
+// plugins
+const graphqlPlugin = require('./graphql')
+
 // handlers
 const appShellHandler = require('./handlers/app-shell')
 
@@ -13,6 +16,7 @@ module.exports = () => {
     root: path.join(process.cwd(), 'build/public')
   })
 
+  app.register(graphqlPlugin)
   app.get('/', appShellHandler)
 
   app.listen(3000)


### PR DESCRIPTION
Since `fastify-gql` supports GraphiQL plugin which when mounted is available at http://127.0.0.1:3000/graphiql.html, I am adding this to part-1. Let's check at the catchup call with Brian how much GraphQL setup should be prepared in advance.